### PR TITLE
Fix regex for UDP broadcast in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 [![codecov](https://codecov.io/gh/Kuska-ssb/kuska-ssb/branch/master/graph/badge.svg)](https://codecov.io/gh/Kuska-ssb/kuska-ssb)
 
 # kuska-ssb
-Secure Scuttlebut library
+Secure Scuttlebutt library
 
 kuska means _together_ in [Runasimi](https://en.wikipedia.org/wiki/Quechuan_languages)
 
-kuska is an implementation of decentralized social network [Secure Scuttlebut](https://scuttlebutt.nz/) written in rust, it does not aim to provide a user interface and the functionality implemented in some clients like [Patchwork](https://github.com/ssbc/patchwork), [Patchbay](https://github.com/ssbc/patchbay), but the full set of libraries to be able to develop applications for the secure scuttlebut network.
+kuska is an implementation of decentralized social network [Secure Scuttlebutt](https://scuttlebutt.nz/) written in rust, it does not aim to provide a user interface and the functionality implemented in some clients like [Patchwork](https://github.com/ssbc/patchwork), [Patchbay](https://github.com/ssbc/patchbay), but the full set of libraries to be able to develop applications for the secure scuttlebut network.
 
 kuska-ssb is the implementation of protocols involved in ssb (unless the the handhake and box stream that are in the [ssb-handshake repo](https://github.com/Kuska-ssb/kuska-handshake) ), detailed information about the protocol can be found in https://ssbc.github.io/scuttlebutt-protocol-guide/ and https://scuttlebot.io/apis/scuttlebot/ssb.html

--- a/examples/ssb-cli.rs
+++ b/examples/ssb-cli.rs
@@ -153,7 +153,7 @@ async fn main() -> Result<()> {
 
         println!("got broadcasted {}", msg);
         let broadcast_regexp =
-            r"net:([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+):([0-9]+)~shs:([0-9a-zA-Z=/]+)";
+            r"net:([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+):([0-9]+)~shs:([0-9a-zA-Z\+/]+)=";
         let captures = Regex::new(broadcast_regexp)
             .unwrap()
             .captures(&msg)


### PR DESCRIPTION
Hi @adria0 , thanks so much for your amazing work on Kuska-ssb!

I have been attempting to run the `ssb-cli.rs` example on my Pi 3B+. I compiled the example successfully but ran into an error on the Regex capture for the UDP broadcast message (line 282): `Error: InvalidLastSymbol(10, 66)`.

The error occurs because SSB identities can include the `+` character (and not just `0-9`, `a-z`, `A-Z` and `/`).

The example worked after changing the regular expression:

```console
Waiting server broadcast...
got broadcasted net:192.168.1.47:8008~shs:HEqy940T6uB+T+d9Jaa58aNfRzLx9eRWqkZljBmnkmk=;ws://192.168.1.47:8989~shs:HEqy940T6uB+T+d9Jaa58aNfRzLx9e
server_ip_port=192.168.1.47:8008
💃 handshake complete
```

I've also fixed a minor typo in the readme: "Scuttlebut" -> "Scuttlebutt".

I hope this is helpful. I'll probably have some feedback and questions as I progress further with my explorations. Thanks again! :black_heart: 