### PR TITLE
Update kuska dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2018"
 name = "kuska_ssb"
 
 [dependencies]
-kuska-handshake = { git =  "https://github.com/Kuska-ssb/handshake", branch = "master" , features=["sync","async_std"] }
-sodiumoxide = { git = "https://github.com/Dhole/sodiumoxidez", branch = "extra" }
+kuska-handshake = { version = "0.2.0", features = ["sync", "async_std"] }
+kuska-sodiumoxide = "0.2.5-0"
 base64 = "0.11.0"
 hex = "0.4.0"
 async-std = { version = "1.5.0", features=["unstable","attributes"] }

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -2,7 +2,7 @@ mod error;
 mod sodium;
 
 pub use error::{Error, Result};
+pub use kuska_sodiumoxide::crypto::{hash::sha256, sign::ed25519};
 pub use sodium::{
     ToSodiumObject, ToSsbId, CURVE_ED25519_SUFFIX, ED25519_SIGNATURE_SUFFIX, SHA256_SUFFIX,
 };
-pub use sodiumoxide::crypto::{hash::sha256, sign::ed25519};

--- a/src/crypto/sodium.rs
+++ b/src/crypto/sodium.rs
@@ -1,4 +1,4 @@
-use sodiumoxide::crypto::{hash::sha256, sign::ed25519};
+use kuska_sodiumoxide::crypto::{hash::sha256, sign::ed25519};
 
 use super::error::{Error, Result};
 

--- a/src/discovery/network.rs
+++ b/src/discovery/network.rs
@@ -1,4 +1,4 @@
-use sodiumoxide::crypto::auth;
+use kuska_sodiumoxide::crypto::auth;
 
 pub const SSB_NET_ID: &str = "d4a1cb88a66f02f8db635ce26441cc5dac1b08420ceaac230839b755845a9ffb";
 pub fn ssb_net_id() -> auth::Key {

--- a/src/discovery/pubs.rs
+++ b/src/discovery/pubs.rs
@@ -1,5 +1,5 @@
 use crate::crypto::ToSodiumObject;
-use sodiumoxide::crypto::sign::ed25519;
+use kuska_sodiumoxide::crypto::sign::ed25519;
 
 use super::error::{Error, Result};
 

--- a/src/feed/encoding.rs
+++ b/src/feed/encoding.rs
@@ -1,6 +1,6 @@
 use super::error::Result;
+use kuska_sodiumoxide::crypto::hash::sha256;
 use serde_json::Value;
-use sodiumoxide::crypto::hash::sha256;
 
 pub fn ssb_sha256(v: &Value) -> Result<sha256::Digest> {
     let v8encoding = stringify_json(&v)?

--- a/src/feed/message.rs
+++ b/src/feed/message.rs
@@ -1,14 +1,14 @@
 use std::{str::FromStr, time::SystemTime};
 
+use kuska_sodiumoxide::crypto::sign::ed25519;
 use serde_json::Value;
-use sodiumoxide::crypto::sign::ed25519;
 
 use super::{
     error::{Error, Result},
     ssb_sha256, stringify_json,
 };
 use crate::{crypto::ToSodiumObject, keystore::OwnedIdentity};
-use sodiumoxide::crypto::hash::sha256;
+use kuska_sodiumoxide::crypto::hash::sha256;
 
 const MSG_PREVIOUS: &str = "previous";
 const MSG_AUTHOR: &str = "author";
@@ -23,7 +23,7 @@ macro_rules! cast {
         match $input {
             Some($pth(x)) => Ok(x),
             _ => Err(Error::InvalidJson),
-        };
+        }
     };
 }
 
@@ -34,7 +34,7 @@ macro_rules! cast_opt {
             Some(Value::Null) => Ok(None),
             Some($pth(x)) => Ok(Some(x)),
             _ => Err(Error::InvalidJson),
-        };
+        }
     };
 }
 

--- a/src/feed/privatebox.rs
+++ b/src/feed/privatebox.rs
@@ -1,6 +1,6 @@
 use crate::crypto::ToSodiumObject;
 
-use sodiumoxide::crypto::{
+use kuska_sodiumoxide::crypto::{
     scalarmult::curve25519,
     secretbox,
     sign::{ed25519, SecretKey},
@@ -57,7 +57,7 @@ fn cipher(plaintext: &[u8], recipients: &[&ed25519::PublicKey]) -> Result<Box<[u
     let (h_pk, h_sk) = ed25519::gen_keypair();
 
     // Generated random 32-byte secret key used to encrypt the message body
-    let y = sodiumoxide::crypto::secretbox::gen_key();
+    let y = kuska_sodiumoxide::crypto::secretbox::gen_key();
 
     // Encrypt the plaintext with y, with a random nonce
     let nonce = secretbox::gen_nonce();

--- a/src/keystore/identity.rs
+++ b/src/keystore/identity.rs
@@ -1,5 +1,5 @@
 use crate::crypto::CURVE_ED25519_SUFFIX;
-use sodiumoxide::crypto::sign::ed25519;
+use kuska_sodiumoxide::crypto::sign::ed25519;
 
 #[derive(Debug, Clone)]
 pub struct OwnedIdentity {


### PR DESCRIPTION
Hey @adria0 , I hope you're doing well :) I'm starting to play with some of the kuska libraries again.

-----

Here we have a simple PR to define the `kuska-handshake` and `kuska-sodiumoxide` dependencies using crates and not git repo paths.

Prior to making the change, `ssb` would not compile on my machine due to dependency conflicts involving lib-sodium. I have no compilation errors after this change.

I have also changed `sodiumoxide` -> `kuska-sodiumoxide` throughout.

P.s. I might need to make additional changes to satisfy `clippy` and pass CI checks. I'd be happy to do that; just didn't want to include it in this PR straight away.