### PR TITLE
Add go-ssb keystore functionality

### DIFF
--- a/src/keystore/gosbot.rs
+++ b/src/keystore/gosbot.rs
@@ -7,17 +7,11 @@ use async_std::{
     prelude::*,
 };
 
-use std::string::ToString;
-
 use super::{
     error::{Error, Result},
-    JsonSSBSecret, OwnedIdentity, CURVE_ED25519,
+    util, JsonSSBSecret, OwnedIdentity, CURVE_ED25519,
 };
 use crate::crypto::{ToSodiumObject, ToSsbId};
-
-fn to_io_error<T: ToString>(err: T) -> async_std::io::Error {
-    async_std::io::Error::new(std::io::ErrorKind::Other, err.to_string())
-}
 
 /// Return an `OwnedIdentity` from the local go-sbot secret file.
 pub async fn from_gosbot_local() -> Result<OwnedIdentity> {
@@ -34,7 +28,7 @@ pub async fn read_gosbot_config<R: Read + Unpin>(reader: &mut R) -> Result<Owned
     reader.read_to_string(&mut buf).await?;
 
     // parse json
-    let secret: JsonSSBSecret = serde_json::from_str(buf.as_ref()).map_err(to_io_error)?;
+    let secret: JsonSSBSecret = serde_json::from_str(buf.as_ref()).map_err(util::to_io_error)?;
 
     if secret.curve != CURVE_ED25519 {
         return Err(Error::InvalidConfig);

--- a/src/keystore/gosbot.rs
+++ b/src/keystore/gosbot.rs
@@ -1,0 +1,98 @@
+//! Read and write a go-sbot secret (identity) file.
+
+#![warn(missing_docs)]
+
+use async_std::{
+    io::{Read, Write},
+    prelude::*,
+};
+
+use std::string::ToString;
+
+use super::{
+    error::{Error, Result},
+    CURVE_ED25519,
+    OwnedIdentity,
+    JsonSSBSecret,
+};
+use crate::crypto::{ToSodiumObject, ToSsbId};
+
+fn to_io_error<T: ToString>(err: T) -> async_std::io::Error {
+    async_std::io::Error::new(std::io::ErrorKind::Other, err.to_string())
+}
+
+/// Return an `OwnedIdentity` from the local go-sbot secret file.
+pub async fn from_gosbot_local() -> Result<OwnedIdentity> {
+    let home_dir = dirs::home_dir().ok_or(Error::HomeNotFound)?;
+    let local_key_file = format!("{}/.ssb-go/secret", home_dir.to_string_lossy());
+    let mut file = async_std::fs::File::open(local_key_file).await?;
+    read_gosbot_config(&mut file).await
+}
+
+/// Read the contents of the go-sbot secret file, deserialize into a 
+/// `JsonSSBSecret` and return an `OwnedIdentity`.
+pub async fn read_gosbot_config<R: Read + Unpin>(reader: &mut R) -> Result<OwnedIdentity> {
+    let mut buf = String::new();
+    reader.read_to_string(&mut buf).await?;
+
+    // parse json
+    let secret: JsonSSBSecret = serde_json::from_str(buf.as_ref()).map_err(to_io_error)?;
+
+    if secret.curve != CURVE_ED25519 {
+        return Err(Error::InvalidConfig);
+    }
+
+    Ok(OwnedIdentity {
+        id: secret.id,
+        pk: secret.public.to_ed25519_pk()?,
+        sk: secret.private.to_ed25519_sk()?,
+    })
+}
+
+/// Write an `OwnedIdentity`.
+pub async fn write_gosbot_config<W: Write + Unpin>(
+    id: &OwnedIdentity,
+    writer: &mut W,
+) -> Result<()> {
+    let json = JsonSSBSecret {
+        curve: CURVE_ED25519.to_owned(),
+        id: id.id.clone(),
+        private: id.sk.to_ssb_id(),
+        public: id.pk.to_ssb_id(),
+    };
+    let encoded = serde_json::to_vec(&json)?;
+    Ok(writer.write_all(&encoded).await?)
+}
+
+#[cfg(test)]
+mod test {
+    use async_std::io::Cursor;
+    use super::*;
+
+    // ssb secret file contents, as formatted by go-sbot
+    const SECRET: &str = r#"{"curve":"ed25519","id":"@1vxS6DMi7z9uJIQG33W7mlsv21GZIbOpmWE1QEcn9oY=.ed25519","private":"F9bw6dPLaHR89hg6Q2dRmoNHHjm+COI53L0kdV3Y4w3W/FLoMyLvP24khAbfdbuaWy/bUZkhs6mZYTVARyf2hg==.ed25519","public":"1vxS6DMi7z9uJIQG33W7mlsv21GZIbOpmWE1QEcn9oY=.ed25519"}"#;
+
+    #[async_std::test]
+    async fn test_gosbot_secret() -> Result<()> {
+        let mut secret_bytes = SECRET.as_bytes();
+        let read_secret_output = read_gosbot_config(&mut secret_bytes).await?;
+        let expected = OwnedIdentity { 
+            id: "@1vxS6DMi7z9uJIQG33W7mlsv21GZIbOpmWE1QEcn9oY=.ed25519".to_owned(),
+            sk: "F9bw6dPLaHR89hg6Q2dRmoNHHjm+COI53L0kdV3Y4w3W/FLoMyLvP24khAbfdbuaWy/bUZkhs6mZYTVARyf2hg==.ed25519".to_ed25519_sk()?,
+            pk: "1vxS6DMi7z9uJIQG33W7mlsv21GZIbOpmWE1QEcn9oY=.ed25519".to_ed25519_pk()?
+        };
+        assert_eq!(expected, read_secret_output);
+       
+        // create a Cursor which wraps an in-memory buffer (implements `Write`)
+        let mut secret_buffer = Cursor::new(Vec::new());
+        // write the `OwnedIdentity` from `read_gosbot_config()` to the buffer
+        write_gosbot_config(&read_secret_output, &mut secret_buffer).await?;
+        // retrieve the value from inside the Cursor
+        let secret_vector = secret_buffer.into_inner();
+        // convert the byte slice to a string slice
+        let write_secret_output = std::str::from_utf8(&secret_vector).unwrap();
+        assert_eq!(SECRET, write_secret_output);
+
+        Ok(())
+    }
+}

--- a/src/keystore/gosbot.rs
+++ b/src/keystore/gosbot.rs
@@ -11,9 +11,7 @@ use std::string::ToString;
 
 use super::{
     error::{Error, Result},
-    CURVE_ED25519,
-    OwnedIdentity,
-    JsonSSBSecret,
+    JsonSSBSecret, OwnedIdentity, CURVE_ED25519,
 };
 use crate::crypto::{ToSodiumObject, ToSsbId};
 
@@ -29,7 +27,7 @@ pub async fn from_gosbot_local() -> Result<OwnedIdentity> {
     read_gosbot_config(&mut file).await
 }
 
-/// Read the contents of the go-sbot secret file, deserialize into a 
+/// Read the contents of the go-sbot secret file, deserialize into a
 /// `JsonSSBSecret` and return an `OwnedIdentity`.
 pub async fn read_gosbot_config<R: Read + Unpin>(reader: &mut R) -> Result<OwnedIdentity> {
     let mut buf = String::new();
@@ -66,8 +64,8 @@ pub async fn write_gosbot_config<W: Write + Unpin>(
 
 #[cfg(test)]
 mod test {
-    use async_std::io::Cursor;
     use super::*;
+    use async_std::io::Cursor;
 
     // ssb secret file contents, as formatted by go-sbot
     const SECRET: &str = r#"{"curve":"ed25519","id":"@1vxS6DMi7z9uJIQG33W7mlsv21GZIbOpmWE1QEcn9oY=.ed25519","private":"F9bw6dPLaHR89hg6Q2dRmoNHHjm+COI53L0kdV3Y4w3W/FLoMyLvP24khAbfdbuaWy/bUZkhs6mZYTVARyf2hg==.ed25519","public":"1vxS6DMi7z9uJIQG33W7mlsv21GZIbOpmWE1QEcn9oY=.ed25519"}"#;
@@ -76,13 +74,13 @@ mod test {
     async fn test_gosbot_secret() -> Result<()> {
         let mut secret_bytes = SECRET.as_bytes();
         let read_secret_output = read_gosbot_config(&mut secret_bytes).await?;
-        let expected = OwnedIdentity { 
+        let expected = OwnedIdentity {
             id: "@1vxS6DMi7z9uJIQG33W7mlsv21GZIbOpmWE1QEcn9oY=.ed25519".to_owned(),
             sk: "F9bw6dPLaHR89hg6Q2dRmoNHHjm+COI53L0kdV3Y4w3W/FLoMyLvP24khAbfdbuaWy/bUZkhs6mZYTVARyf2hg==.ed25519".to_ed25519_sk()?,
             pk: "1vxS6DMi7z9uJIQG33W7mlsv21GZIbOpmWE1QEcn9oY=.ed25519".to_ed25519_pk()?
         };
         assert_eq!(expected, read_secret_output);
-       
+
         // create a Cursor which wraps an in-memory buffer (implements `Write`)
         let mut secret_buffer = Cursor::new(Vec::new());
         // write the `OwnedIdentity` from `read_gosbot_config()` to the buffer

--- a/src/keystore/identity.rs
+++ b/src/keystore/identity.rs
@@ -1,7 +1,18 @@
 use crate::crypto::CURVE_ED25519_SUFFIX;
 use kuska_sodiumoxide::crypto::sign::ed25519;
 
-#[derive(Debug, Clone)]
+/// Ed25519 signature scheme identifier.
+pub const CURVE_ED25519: &str = "ed25519";
+
+#[derive(Serialize, Deserialize)]
+pub struct JsonSSBSecret {
+    pub curve: String,
+    pub id: String,
+    pub private: String,
+    pub public: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct OwnedIdentity {
     pub id: String,
     pub pk: ed25519::PublicKey,

--- a/src/keystore/mod.rs
+++ b/src/keystore/mod.rs
@@ -2,6 +2,7 @@ mod error;
 pub mod gosbot;
 mod identity;
 pub mod patchwork;
+mod util;
 
 pub use gosbot::{from_gosbot_local, read_gosbot_config, write_gosbot_config};
 pub use identity::{JsonSSBSecret, OwnedIdentity, CURVE_ED25519};

--- a/src/keystore/mod.rs
+++ b/src/keystore/mod.rs
@@ -1,6 +1,8 @@
 mod error;
+pub mod gosbot;
 mod identity;
 pub mod patchwork;
 
-pub use identity::OwnedIdentity;
+pub use gosbot::{from_gosbot_local, read_gosbot_config, write_gosbot_config};
+pub use identity::{JsonSSBSecret, OwnedIdentity, CURVE_ED25519};
 pub use patchwork::{from_patchwork_local, read_patchwork_config, write_patchwork_config};

--- a/src/keystore/patchwork.rs
+++ b/src/keystore/patchwork.rs
@@ -3,18 +3,12 @@ use async_std::{
     prelude::*,
 };
 
-use std::string::ToString;
-
 use super::{
     error::{Error, Result},
-    JsonSSBSecret, OwnedIdentity, CURVE_ED25519,
+    util, JsonSSBSecret, OwnedIdentity, CURVE_ED25519,
 };
 use crate::crypto::{ToSodiumObject, ToSsbId};
 use serde_json::to_vec_pretty;
-
-fn to_io_error<T: ToString>(err: T) -> async_std::io::Error {
-    async_std::io::Error::new(std::io::ErrorKind::Other, err.to_string())
-}
 
 pub async fn from_patchwork_local() -> Result<OwnedIdentity> {
     let home_dir = dirs::home_dir().ok_or(Error::HomeNotFound)?;
@@ -34,7 +28,7 @@ pub async fn read_patchwork_config<R: Read + Unpin>(reader: &mut R) -> Result<Ow
         .join("");
 
     // parse json
-    let secret: JsonSSBSecret = serde_json::from_str(json.as_ref()).map_err(to_io_error)?;
+    let secret: JsonSSBSecret = serde_json::from_str(json.as_ref()).map_err(util::to_io_error)?;
 
     if secret.curve != CURVE_ED25519 {
         return Err(Error::InvalidConfig);

--- a/src/keystore/patchwork.rs
+++ b/src/keystore/patchwork.rs
@@ -7,20 +7,10 @@ use std::string::ToString;
 
 use super::{
     error::{Error, Result},
-    OwnedIdentity,
+    JsonSSBSecret, OwnedIdentity, CURVE_ED25519,
 };
 use crate::crypto::{ToSodiumObject, ToSsbId};
 use serde_json::to_vec_pretty;
-
-pub const CURVE_ED25519: &str = "ed25519";
-
-#[derive(Serialize, Deserialize)]
-struct JsonSSBSecret {
-    id: String,
-    curve: String,
-    public: String,
-    private: String,
-}
 
 fn to_io_error<T: ToString>(err: T) -> async_std::io::Error {
     async_std::io::Error::new(std::io::ErrorKind::Other, err.to_string())

--- a/src/keystore/util.rs
+++ b/src/keystore/util.rs
@@ -1,0 +1,5 @@
+use std::string::ToString;
+
+pub fn to_io_error<T: ToString>(err: T) -> async_std::io::Error {
+    async_std::io::Error::new(std::io::ErrorKind::Other, err.to_string())
+}


### PR DESCRIPTION
@adria0 Here's a small PR to facilitate easier go-sbot interop.

 - Move `JsonSSBSecret` & `CURVE_ED25519` to `identity.rs`
 - Implement `PartialEq` on `OwnedIdentity` (useful for testing)
 - Add reader and writer functions for `~/.ssb-go/secret`
   - Add tests and doc comments