### PR TITLE
Add publish RPC support

### DIFF
--- a/src/api/dto/content.rs
+++ b/src/api/dto/content.rs
@@ -32,28 +32,28 @@ impl Post {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct PubAddress {
     pub host: Option<String>,
     pub port: u16,
     pub key: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum VoteValue {
     Numeric(i64),
     Boolean(bool),
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Vote {
     link: SsbHash,
     value: VoteValue,
     expression: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Image {
     OnlyLink(SsbHash),
@@ -68,7 +68,7 @@ pub enum Image {
     },
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct DateTime {
     epoch: u64,
     tz: String,
@@ -90,7 +90,7 @@ pub enum Mentions {
     Map(HashMap<String, Mention>),
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum TypedMessage {
     #[serde(rename = "pub")]


### PR DESCRIPTION
This PR adds the ability to make a `publish` RPC request (using the `TypedMessage enum`) and receive a response (the reference / key for the published message).

The `msg_ref` is returned as a `String`.

-----

@adria0 

I wonder if you would prefer the return value to be a (new) `PublishOut` type? That would follow the pattern you used for `WhoAmIOut`. It might look like this:

`src/api/dto/publish.rs`

```rust
#[derive(Debug, Serialize, Deserialize)]
pub struct PublishOut {
    pub msg_ref: String,
}
```

I used `String` for `msg_ref` in this PR because it was simple to implement.