### PR TITLE
Support getSubset queries

### DIFF
--- a/src/api/dto/content.rs
+++ b/src/api/dto/content.rs
@@ -8,6 +8,7 @@ pub type SsbId = String;
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Mention {
     pub link: SsbId,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
@@ -16,6 +17,7 @@ pub struct Post {
     #[serde(rename = "type")]
     pub xtype: String,
     pub text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mentions: Option<Vec<Mention>>,
 }
 
@@ -34,6 +36,7 @@ impl Post {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PubAddress {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub host: Option<String>,
     pub port: u16,
     pub key: String,
@@ -50,6 +53,7 @@ pub enum VoteValue {
 pub struct Vote {
     link: SsbHash,
     value: VoteValue,
+    #[serde(skip_serializing_if = "Option::is_none")]
     expression: Option<String>,
 }
 
@@ -59,9 +63,12 @@ pub enum Image {
     OnlyLink(SsbHash),
     Complete {
         link: SsbHash,
+        #[serde(skip_serializing_if = "Option::is_none")]
         name: Option<String>,
         size: u64,
+        #[serde(skip_serializing_if = "Option::is_none")]
         width: Option<u32>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         height: Option<u32>,
         #[serde(rename = "type")]
         content_type: String,
@@ -98,24 +105,35 @@ pub enum TypedMessage {
     #[serde(rename = "post")]
     Post {
         text: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
         mentions: Option<Vec<Mention>>,
     },
     #[serde(rename = "contact")]
     Contact {
         contact: Option<SsbId>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         blocking: Option<bool>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         following: Option<bool>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         autofollow: Option<bool>,
     },
     #[serde(rename = "about")]
     About {
         about: SsbId,
+        #[serde(skip_serializing_if = "Option::is_none")]
         name: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         title: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         branch: Option<SsbHash>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         image: Option<Image>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         description: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         location: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         #[serde(rename = "startDateTime")]
         start_datetime: Option<DateTime>,
     },

--- a/src/api/dto/content.rs
+++ b/src/api/dto/content.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 
 pub type SsbHash = String;
 pub type SsbId = String;
+pub type SsbMsgType = String;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Mention {
@@ -141,4 +142,23 @@ pub enum TypedMessage {
     Channel { channel: String, subscribed: bool },
     #[serde(rename = "vote")]
     Vote { vote: Vote },
+}
+
+//op 	    args name 	args type
+//and 	    args 	[op, ...]
+//or 	    args 	[op, ...]
+//type 	    string 	string
+//author    feed 	string
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum SubsetQuery {
+    // {"op":"type","string":"foo"}
+    Type { op: String, string: SsbMsgType },
+    //#[serde(rename = "author")]
+    Author { op: String, feed: SsbId },
+    //#[serde(rename = "and")]
+    //And { args: Vec<SubsetQuery> },
+    //#[serde(rename = "or")]
+    //Or { args: Vec<SubsetQuery> },
 }

--- a/src/api/dto/content.rs
+++ b/src/api/dto/content.rs
@@ -144,21 +144,13 @@ pub enum TypedMessage {
     Vote { vote: Vote },
 }
 
-//op 	    args name 	args type
-//and 	    args 	[op, ...]
-//or 	    args 	[op, ...]
-//type 	    string 	string
-//author    feed 	string
-
+/// An ssb-ql-1 query as defined by the 'Subset replication for SSB'
+/// specification.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum SubsetQuery {
-    // {"op":"type","string":"foo"}
     Type { op: String, string: SsbMsgType },
-    //#[serde(rename = "author")]
     Author { op: String, feed: SsbId },
-    //#[serde(rename = "and")]
-    //And { args: Vec<SubsetQuery> },
-    //#[serde(rename = "or")]
-    //Or { args: Vec<SubsetQuery> },
+    And { op: String, args: Vec<SubsetQuery> },
+    Or { op: String, args: Vec<SubsetQuery> },
 }

--- a/src/api/helper.rs
+++ b/src/api/helper.rs
@@ -1,5 +1,5 @@
 use crate::{
-    api::dto::content::TypedMessage,
+    api::dto::content::{SubsetQuery, TypedMessage},
     feed::Message,
     rpc::{Body, BodyType, RequestNo, RpcType, RpcWriter},
 };


### PR DESCRIPTION
Adds support for the `partialReplication.getSubset` RPC call (request only), as defined by the [Subset replication for SSB](https://github.com/ssb-ngi-pointer/ssb-subset-replication-spec) specification.

Confirmed working with `go-sbot` on my local machine.

**Example usage**

```rust
use kuska_ssb::api::dto::content::SubsetQuery;

let type_query = SubsetQuery::Type {
    op: "type".to_string(),
    string: "post".to_string(),
};

let type_query_response = sbot_client.getsubset(type_query).await?;

let author_query = SubsetQuery::Author {
    op: "author".to_string(),
    feed: "@1vxS6DMi7z9uJIQG33W7mlsv21GZIbOpmWE1QEcn9oY=.ed25519".to_string(),
};

let author_query_response = sbot_client.getsubset(author_query).await?;

let and_query = SubsetQuery::And {
    op: "and".to_string(),
    args: vec![author_query, type_query],
};

let and_query_response = sbot_client.getsubset(and_query).await?;
```