### PR TITLE
Support options argument for getSubset queries

### DIFF
--- a/src/api/dto/content.rs
+++ b/src/api/dto/content.rs
@@ -154,3 +154,16 @@ pub enum SubsetQuery {
     And { op: String, args: Vec<SubsetQuery> },
     Or { op: String, args: Vec<SubsetQuery> },
 }
+
+/// Optional parameters for defining the order, shape and length of
+/// returned query data.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SubsetQueryOptions {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub descending: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub keys: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "pageLimit")]
+    pub page_limit: Option<u32>,
+}

--- a/src/api/helper.rs
+++ b/src/api/helper.rs
@@ -1,5 +1,5 @@
 use crate::{
-    api::dto::content::{SubsetQuery, TypedMessage},
+    api::dto::content::{SubsetQuery, SubsetQueryOptions, TypedMessage},
     feed::Message,
     rpc::{Body, BodyType, RequestNo, RpcType, RpcWriter},
 };
@@ -72,10 +72,19 @@ impl<W: Write + Unpin> ApiCaller<W> {
     }
 
     /// Send ["partialReplication", "getSubset"] request.
-    pub async fn getsubset_req_send(&mut self, query: SubsetQuery) -> Result<RequestNo> {
+    pub async fn getsubset_req_send(
+        &mut self,
+        query: SubsetQuery,
+        opts: Option<SubsetQueryOptions>,
+    ) -> Result<RequestNo> {
         let req_no = self
             .rpc
-            .send_request(ApiMethod::GetSubset.selector(), RpcType::Source, &query)
+            .send_request(
+                ApiMethod::GetSubset.selector(),
+                RpcType::Source,
+                &query,
+                &opts,
+            )
             .await?;
         Ok(req_no)
     }
@@ -84,7 +93,13 @@ impl<W: Write + Unpin> ApiCaller<W> {
     pub async fn publish_req_send(&mut self, msg: TypedMessage) -> Result<RequestNo> {
         let req_no = self
             .rpc
-            .send_request(ApiMethod::Publish.selector(), RpcType::Async, &msg)
+            .send_request(
+                ApiMethod::Publish.selector(),
+                RpcType::Async,
+                &msg,
+                // specify None value for `opts`
+                &None::<()>,
+            )
             .await?;
         Ok(req_no)
     }
@@ -102,7 +117,12 @@ impl<W: Write + Unpin> ApiCaller<W> {
         let args: [&str; 0] = [];
         let req_no = self
             .rpc
-            .send_request(ApiMethod::WhoAmI.selector(), RpcType::Async, &args)
+            .send_request(
+                ApiMethod::WhoAmI.selector(),
+                RpcType::Async,
+                &args,
+                &None::<()>,
+            )
             .await?;
         Ok(req_no)
     }
@@ -120,7 +140,12 @@ impl<W: Write + Unpin> ApiCaller<W> {
     pub async fn get_req_send(&mut self, msg_id: &str) -> Result<RequestNo> {
         let req_no = self
             .rpc
-            .send_request(ApiMethod::Get.selector(), RpcType::Async, &msg_id)
+            .send_request(
+                ApiMethod::Get.selector(),
+                RpcType::Async,
+                &msg_id,
+                &None::<()>,
+            )
             .await?;
         Ok(req_no)
     }
@@ -149,6 +174,7 @@ impl<W: Write + Unpin> ApiCaller<W> {
                 ApiMethod::CreateHistoryStream.selector(),
                 RpcType::Source,
                 &args,
+                &None::<()>,
             )
             .await?;
         Ok(req_no)
@@ -165,6 +191,7 @@ impl<W: Write + Unpin> ApiCaller<W> {
                 ApiMethod::CreateFeedStream.selector(),
                 RpcType::Source,
                 &args,
+                &None::<()>,
             )
             .await?;
         Ok(req_no)
@@ -175,7 +202,12 @@ impl<W: Write + Unpin> ApiCaller<W> {
         let args: [&str; 0] = [];
         let req_no = self
             .rpc
-            .send_request(ApiMethod::Latest.selector(), RpcType::Async, &args)
+            .send_request(
+                ApiMethod::Latest.selector(),
+                RpcType::Async,
+                &args,
+                &None::<()>,
+            )
             .await?;
         Ok(req_no)
     }
@@ -184,7 +216,12 @@ impl<W: Write + Unpin> ApiCaller<W> {
     pub async fn blobs_get_req_send(&mut self, args: &dto::BlobsGetIn) -> Result<RequestNo> {
         let req_no = self
             .rpc
-            .send_request(ApiMethod::BlobsGet.selector(), RpcType::Source, &args)
+            .send_request(
+                ApiMethod::BlobsGet.selector(),
+                RpcType::Source,
+                &args,
+                &None::<()>,
+            )
             .await?;
         Ok(req_no)
     }
@@ -206,6 +243,7 @@ impl<W: Write + Unpin> ApiCaller<W> {
                 ApiMethod::BlobsCreateWants.selector(),
                 RpcType::Source,
                 &args,
+                &None::<()>,
             )
             .await?;
         Ok(req_no)


### PR DESCRIPTION
As described in https://github.com/Kuska-ssb/ssb/issues/19:

> When making a `partialReplication.getSubset` RPC call, it is possible to specify (optional) options to the query

This PR adds support for subset options by defining the `SubsetQueryOptions` `struct` and adding an optional argument to the `send_request()` function.

-----

My first solution-attempt changed the `args` field of `BodyRef` to a tuple. This works for the subset query but unfortunately not for some of the other calls, such as `publish`. go-sbot returns an error when a publish RPC call is made with `null` as the second argument. 

```rust
#[derive(Serialize)]
pub struct BodyRef<'a, T: serde::Serialize, U: serde::Serialize> {
    pub name: &'a [&'a str],
    #[serde(rename = "type")]
    pub rpc_type: RpcType,
    pub args: (&'a T, &'a Option<U>),
}
```

And so, I made a second `BodyRef` `struct` and match on the value of `opts` in `send_request()`. This should be flexible enough to allow other option types to be passed to RPC calls as the second argument.

CC: @adria0 