### PR TITLE
Introduce friends API requests

### DIFF
--- a/src/api/dto/content.rs
+++ b/src/api/dto/content.rs
@@ -167,3 +167,25 @@ pub struct SubsetQueryOptions {
     #[serde(rename = "pageLimit")]
     pub page_limit: Option<u32>,
 }
+
+/// Query the follow or block state of two peers.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RelationshipQuery {
+    pub source: String,
+    pub dest: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FriendsHops {
+    /// A maximum hops distance. Nodes beyond this distance are omitted from
+    /// the output.
+    pub max: i32,
+    /// Reverse the perspective when calculating hops distance; from `start`
+    /// looking "out" (`false`) or from the peer ID(s) looking "in" (`true`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reverse: Option<bool>,
+    /// Feed ID of the "central" node where distance is zero.
+    /// (Default: sbot.id).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start: Option<String>,
+}


### PR DESCRIPTION
This PR introduces RPC request calls for three methods:

`friends.hops`
`friends.isBlocking`
`friends.isFollowing`

A `RelationshipQuery` `struct` is defined and is expected as an argument to the `friends_is_following_req_send` and `friends_is_blocking_req_send` methods.

A `FriendsHops` `struct` is also provided and must be passed into the `friends_hops_req_send` method.

CC: @adria0 