### PR TITLE
Introduce invite RPC requests

### DIFF
--- a/src/api/dto/content.rs
+++ b/src/api/dto/content.rs
@@ -189,3 +189,9 @@ pub struct FriendsHops {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub start: Option<String>,
 }
+
+/// Optional parameter for defining the number of times an invite can be used.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct InviteCreateOptions {
+    pub uses: u16,
+}

--- a/src/api/helper.rs
+++ b/src/api/helper.rs
@@ -1,6 +1,7 @@
 use crate::{
     api::dto::content::{
-        FriendsHops, RelationshipQuery, SubsetQuery, SubsetQueryOptions, TypedMessage,
+        FriendsHops, InviteCreateOptions, RelationshipQuery, SubsetQuery, SubsetQueryOptions,
+        TypedMessage,
     },
     feed::Message,
     rpc::{Body, BodyType, RequestNo, RpcType, RpcWriter},
@@ -13,6 +14,8 @@ const MAX_RPC_BODY_LEN: usize = 65536;
 
 #[derive(Debug)]
 pub enum ApiMethod {
+    InviteCreate,
+    InviteUse,
     FriendsIsFollowing,
     FriendsIsBlocking,
     FriendsHops,
@@ -31,6 +34,8 @@ impl ApiMethod {
     pub fn selector(&self) -> &'static [&'static str] {
         use ApiMethod::*;
         match self {
+            InviteCreate => &["invite", "create"],
+            InviteUse => &["invite", "use"],
             FriendsIsFollowing => &["friends", "isFollowing"],
             FriendsIsBlocking => &["friends", "isBlocking"],
             FriendsHops => &["friends", "hops"],
@@ -48,6 +53,8 @@ impl ApiMethod {
     pub fn from_selector(s: &[&str]) -> Option<Self> {
         use ApiMethod::*;
         match s {
+            ["invite", "create"] => Some(InviteCreate),
+            ["invite", "use"] => Some(InviteUse),
             ["friends", "isFollowing"] => Some(FriendsIsFollowing),
             ["friends", "isBlocking"] => Some(FriendsIsBlocking),
             ["friends", "hops"] => Some(FriendsHops),
@@ -80,6 +87,35 @@ impl<W: Write + Unpin> ApiCaller<W> {
 
     pub fn rpc(&mut self) -> &mut RpcWriter<W> {
         &mut self.rpc
+    }
+
+    /// Send ["invite", "create"] request.
+    pub async fn invite_create_req_send(&mut self, uses: u16) -> Result<RequestNo> {
+        let args = InviteCreateOptions { uses };
+        let req_no = self
+            .rpc
+            .send_request(
+                ApiMethod::InviteCreate.selector(),
+                RpcType::Async,
+                &args,
+                &None::<()>,
+            )
+            .await?;
+        Ok(req_no)
+    }
+
+    /// Send ["invite", "use"] request.
+    pub async fn invite_use_req_send(&mut self, invite_code: &str) -> Result<RequestNo> {
+        let req_no = self
+            .rpc
+            .send_request(
+                ApiMethod::InviteUse.selector(),
+                RpcType::Async,
+                &invite_code,
+                &None::<()>,
+            )
+            .await?;
+        Ok(req_no)
     }
 
     /// Send ["friends", "isFollowing"] request.

--- a/src/api/helper.rs
+++ b/src/api/helper.rs
@@ -4,7 +4,7 @@ use crate::{
         TypedMessage,
     },
     feed::Message,
-    rpc::{Body, BodyType, RequestNo, RpcType, RpcWriter},
+    rpc::{ArgType, Body, BodyType, RequestNo, RpcType, RpcWriter},
 };
 use async_std::io::Write;
 
@@ -97,7 +97,9 @@ impl<W: Write + Unpin> ApiCaller<W> {
             .send_request(
                 ApiMethod::InviteCreate.selector(),
                 RpcType::Async,
+                ArgType::Object,
                 &args,
+                // specify None value for `opts`
                 &None::<()>,
             )
             .await?;
@@ -111,6 +113,7 @@ impl<W: Write + Unpin> ApiCaller<W> {
             .send_request(
                 ApiMethod::InviteUse.selector(),
                 RpcType::Async,
+                ArgType::Array,
                 &invite_code,
                 &None::<()>,
             )
@@ -128,8 +131,8 @@ impl<W: Write + Unpin> ApiCaller<W> {
             .send_request(
                 ApiMethod::FriendsIsFollowing.selector(),
                 RpcType::Async,
+                ArgType::Array,
                 &args,
-                // specify None value for `opts`
                 &None::<()>,
             )
             .await?;
@@ -146,8 +149,8 @@ impl<W: Write + Unpin> ApiCaller<W> {
             .send_request(
                 ApiMethod::FriendsIsBlocking.selector(),
                 RpcType::Async,
+                ArgType::Array,
                 &args,
-                // specify None value for `opts`
                 &None::<()>,
             )
             .await?;
@@ -161,8 +164,8 @@ impl<W: Write + Unpin> ApiCaller<W> {
             .send_request(
                 ApiMethod::FriendsHops.selector(),
                 RpcType::Source,
+                ArgType::Array,
                 &args,
-                // specify None value for `opts`
                 &None::<()>,
             )
             .await?;
@@ -180,6 +183,7 @@ impl<W: Write + Unpin> ApiCaller<W> {
             .send_request(
                 ApiMethod::GetSubset.selector(),
                 RpcType::Source,
+                ArgType::Tuple,
                 &query,
                 &opts,
             )
@@ -194,8 +198,8 @@ impl<W: Write + Unpin> ApiCaller<W> {
             .send_request(
                 ApiMethod::Publish.selector(),
                 RpcType::Async,
+                ArgType::Array,
                 &msg,
-                // specify None value for `opts`
                 &None::<()>,
             )
             .await?;
@@ -218,6 +222,7 @@ impl<W: Write + Unpin> ApiCaller<W> {
             .send_request(
                 ApiMethod::WhoAmI.selector(),
                 RpcType::Async,
+                ArgType::Array,
                 &args,
                 &None::<()>,
             )
@@ -241,6 +246,7 @@ impl<W: Write + Unpin> ApiCaller<W> {
             .send_request(
                 ApiMethod::Get.selector(),
                 RpcType::Async,
+                ArgType::Array,
                 &msg_id,
                 &None::<()>,
             )
@@ -271,6 +277,7 @@ impl<W: Write + Unpin> ApiCaller<W> {
             .send_request(
                 ApiMethod::CreateHistoryStream.selector(),
                 RpcType::Source,
+                ArgType::Array,
                 &args,
                 &None::<()>,
             )
@@ -288,6 +295,7 @@ impl<W: Write + Unpin> ApiCaller<W> {
             .send_request(
                 ApiMethod::CreateFeedStream.selector(),
                 RpcType::Source,
+                ArgType::Array,
                 &args,
                 &None::<()>,
             )
@@ -303,6 +311,7 @@ impl<W: Write + Unpin> ApiCaller<W> {
             .send_request(
                 ApiMethod::Latest.selector(),
                 RpcType::Async,
+                ArgType::Array,
                 &args,
                 &None::<()>,
             )
@@ -317,6 +326,7 @@ impl<W: Write + Unpin> ApiCaller<W> {
             .send_request(
                 ApiMethod::BlobsGet.selector(),
                 RpcType::Source,
+                ArgType::Array,
                 &args,
                 &None::<()>,
             )
@@ -340,6 +350,7 @@ impl<W: Write + Unpin> ApiCaller<W> {
             .send_request(
                 ApiMethod::BlobsCreateWants.selector(),
                 RpcType::Source,
+                ArgType::Array,
                 &args,
                 &None::<()>,
             )

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -2,4 +2,4 @@ mod error;
 mod stream;
 
 pub use error::{Error, Result};
-pub use stream::{Body, BodyType, RecvMsg, RequestNo, RpcReader, RpcType, RpcWriter};
+pub use stream::{ArgType, Body, BodyType, RecvMsg, RequestNo, RpcReader, RpcType, RpcWriter};


### PR DESCRIPTION
Another simple addition. Here we add the ability to send `invite.create` and `invite.use` RPC requests.

`invite.create` has an optional argument to specify the number of uses for the invite being created, ie. "generate an invite code that can be used x times" (where x is the value of `uses`).