### PR TITLE
Add support for custom keyfile paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kuska-ssb"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Dhole <dhole@riseup.net>", "Adria Massanet <adria@codecontext.io>", "Andrew Reid <glyph@mycelial.technology>"]
 edition = "2021"
 description = "Secure Scuttlebutt library"

--- a/src/keystore/gosbot.rs
+++ b/src/keystore/gosbot.rs
@@ -13,12 +13,17 @@ use super::{
 };
 use crate::crypto::{ToSodiumObject, ToSsbId};
 
-/// Return an `OwnedIdentity` from the local go-sbot secret file.
+/// Return an `OwnedIdentity` from the local go-sbot secret file with a custom path
+pub async fn from_custom_gosbot_keypath(local_key_file: String) -> Result<OwnedIdentity> {
+    let mut file = async_std::fs::File::open(local_key_file).await?;
+    read_gosbot_config(&mut file).await
+}
+
+/// Return an `OwnedIdentity` from the local go-sbot secret file in the default location.
 pub async fn from_gosbot_local() -> Result<OwnedIdentity> {
     let home_dir = dirs::home_dir().ok_or(Error::HomeNotFound)?;
     let local_key_file = format!("{}/.ssb-go/secret", home_dir.to_string_lossy());
-    let mut file = async_std::fs::File::open(local_key_file).await?;
-    read_gosbot_config(&mut file).await
+    from_custom_gosbot_keypath(local_key_file).await
 }
 
 /// Read the contents of the go-sbot secret file, deserialize into a

--- a/src/keystore/mod.rs
+++ b/src/keystore/mod.rs
@@ -4,6 +4,6 @@ mod identity;
 pub mod patchwork;
 mod util;
 
-pub use gosbot::{from_gosbot_local, read_gosbot_config, write_gosbot_config};
+pub use gosbot::{from_gosbot_local, read_gosbot_config, write_gosbot_config, from_custom_gosbot_keypath};
 pub use identity::{JsonSSBSecret, OwnedIdentity, CURVE_ED25519};
-pub use patchwork::{from_patchwork_local, read_patchwork_config, write_patchwork_config};
+pub use patchwork::{from_patchwork_local, read_patchwork_config, write_patchwork_config, from_custom_patchwork_keypath};

--- a/src/keystore/mod.rs
+++ b/src/keystore/mod.rs
@@ -4,6 +4,11 @@ mod identity;
 pub mod patchwork;
 mod util;
 
-pub use gosbot::{from_gosbot_local, read_gosbot_config, write_gosbot_config, from_custom_gosbot_keypath};
+pub use gosbot::{
+    from_custom_gosbot_keypath, from_gosbot_local, read_gosbot_config, write_gosbot_config,
+};
 pub use identity::{JsonSSBSecret, OwnedIdentity, CURVE_ED25519};
-pub use patchwork::{from_patchwork_local, read_patchwork_config, write_patchwork_config, from_custom_patchwork_keypath};
+pub use patchwork::{
+    from_custom_patchwork_keypath, from_patchwork_local, read_patchwork_config,
+    write_patchwork_config,
+};

--- a/src/keystore/patchwork.rs
+++ b/src/keystore/patchwork.rs
@@ -10,11 +10,15 @@ use super::{
 use crate::crypto::{ToSodiumObject, ToSsbId};
 use serde_json::to_vec_pretty;
 
+pub async fn from_custom_patchwork_keypath(local_key_file: String) -> Result<OwnedIdentity> {
+    let mut file = async_std::fs::File::open(local_key_file).await?;
+    read_patchwork_config(&mut file).await
+}
+
 pub async fn from_patchwork_local() -> Result<OwnedIdentity> {
     let home_dir = dirs::home_dir().ok_or(Error::HomeNotFound)?;
     let local_key_file = format!("{}/.ssb/secret", home_dir.to_string_lossy());
-    let mut file = async_std::fs::File::open(local_key_file).await?;
-    read_patchwork_config(&mut file).await
+    from_custom_patchwork_keypath(local_key_file).await
 }
 
 pub async fn read_patchwork_config<R: Read + Unpin>(reader: &mut R) -> Result<OwnedIdentity> {


### PR DESCRIPTION
I'm currently working on packaging PeachPub, which makes use of golgi, which makes uses of kuska-ssb, for yunohost (https://yunohost.org/#/)

Yunohost requires apps being installed to custom locations, which means go-sbot will not be running from the standard location, and the secret file will not be in ~/.ssb-go/secret. 

In this PR I add functions to specify a custom key path for go-sbot or patchwork (I actually only need go-sbot for the yunohost package, but I figured why not add both while I'm here for symmetry)