### PR TITLE
Introduce names RPC requests

### DIFF
--- a/src/api/helper.rs
+++ b/src/api/helper.rs
@@ -30,6 +30,7 @@ pub enum ApiMethod {
     NamesGet,
     NamesGetImageFor,
     NamesGetSignifier,
+    PrivatePublish,
     Publish,
     WhoAmI,
 }
@@ -54,6 +55,7 @@ impl ApiMethod {
             NamesGet => &["names", "get"],
             NamesGetImageFor => &["names", "getImageFor"],
             NamesGetSignifier => &["names", "getSignifier"],
+            PrivatePublish => &["private", "publish"],
             Publish => &["publish"],
             WhoAmI => &["whoami"],
         }
@@ -77,6 +79,7 @@ impl ApiMethod {
             ["names", "get"] => Some(NamesGet),
             ["names", "getImageFor"] => Some(NamesGetImageFor),
             ["names", "getSignifier"] => Some(NamesGetSignifier),
+            ["private", "publish"] => Some(PrivatePublish),
             ["publish"] => Some(Publish),
             ["whoami"] => Some(WhoAmI),
             _ => None,
@@ -418,6 +421,25 @@ impl<W: Write + Unpin> ApiCaller<W> {
                 ArgType::Array,
                 &msg,
                 &None::<()>,
+            )
+            .await?;
+        Ok(req_no)
+    }
+
+    /// Send ["private", "publish"] request.
+    pub async fn private_publish_req_send(
+        &mut self,
+        msg: TypedMessage,
+        recipients: Vec<String>,
+    ) -> Result<RequestNo> {
+        let req_no = self
+            .rpc
+            .send_request(
+                ApiMethod::PrivatePublish.selector(),
+                RpcType::Async,
+                ArgType::Tuple,
+                &msg,
+                &Some(recipients),
             )
             .await?;
         Ok(req_no)

--- a/src/api/helper.rs
+++ b/src/api/helper.rs
@@ -14,62 +14,71 @@ const MAX_RPC_BODY_LEN: usize = 65536;
 
 #[derive(Debug)]
 pub enum ApiMethod {
-    InviteCreate,
-    InviteUse,
+    BlobsCreateWants,
+    BlobsGet,
+    CreateFeedStream,
+    CreateHistoryStream,
+    FriendsBlocks,
+    FriendsHops,
     FriendsIsFollowing,
     FriendsIsBlocking,
-    FriendsHops,
-    FriendsBlocks,
+    Get,
     GetSubset,
+    InviteCreate,
+    InviteUse,
+    Latest,
+    NamesGet,
+    NamesGetImageFor,
+    NamesGetSignifier,
     Publish,
     WhoAmI,
-    Get,
-    CreateHistoryStream,
-    CreateFeedStream,
-    Latest,
-    BlobsGet,
-    BlobsCreateWants,
 }
 
 impl ApiMethod {
     pub fn selector(&self) -> &'static [&'static str] {
         use ApiMethod::*;
         match self {
+            BlobsCreateWants => &["blobs", "createWants"],
+            BlobsGet => &["blobs", "get"],
+            CreateFeedStream => &["createFeedStream"],
+            CreateHistoryStream => &["createHistoryStream"],
+            FriendsBlocks => &["friends", "blocks"],
+            FriendsHops => &["friends", "hops"],
+            FriendsIsBlocking => &["friends", "isBlocking"],
+            FriendsIsFollowing => &["friends", "isFollowing"],
+            Get => &["get"],
+            GetSubset => &["partialReplication", "getSubset"],
             InviteCreate => &["invite", "create"],
             InviteUse => &["invite", "use"],
-            FriendsIsFollowing => &["friends", "isFollowing"],
-            FriendsIsBlocking => &["friends", "isBlocking"],
-            FriendsHops => &["friends", "hops"],
-            FriendsBlocks => &["friends", "blocks"],
-            GetSubset => &["partialReplication", "getSubset"],
+            Latest => &["latest"],
+            NamesGet => &["names", "get"],
+            NamesGetImageFor => &["names", "getImageFor"],
+            NamesGetSignifier => &["names", "getSignifier"],
             Publish => &["publish"],
             WhoAmI => &["whoami"],
-            Get => &["get"],
-            CreateHistoryStream => &["createHistoryStream"],
-            CreateFeedStream => &["createFeedStream"],
-            Latest => &["latest"],
-            BlobsGet => &["blobs", "get"],
-            BlobsCreateWants => &["blobs", "createWants"],
         }
     }
     pub fn from_selector(s: &[&str]) -> Option<Self> {
         use ApiMethod::*;
         match s {
+            ["blobs", "createWants"] => Some(BlobsCreateWants),
+            ["blobs", "get"] => Some(BlobsGet),
+            ["createFeedStream"] => Some(CreateFeedStream),
+            ["createHistoryStream"] => Some(CreateHistoryStream),
+            ["friends", "blocks"] => Some(FriendsBlocks),
+            ["friends", "hops"] => Some(FriendsHops),
+            ["friends", "isBlocking"] => Some(FriendsIsBlocking),
+            ["friends", "isFollowing"] => Some(FriendsIsFollowing),
+            ["get"] => Some(Get),
+            ["partialReplication", "getSubset"] => Some(GetSubset),
             ["invite", "create"] => Some(InviteCreate),
             ["invite", "use"] => Some(InviteUse),
-            ["friends", "isFollowing"] => Some(FriendsIsFollowing),
-            ["friends", "isBlocking"] => Some(FriendsIsBlocking),
-            ["friends", "hops"] => Some(FriendsHops),
-            ["friends", "blocks"] => Some(FriendsBlocks),
-            ["partialReplication", "getSubset"] => Some(GetSubset),
+            ["latest"] => Some(Latest),
+            ["names", "get"] => Some(NamesGet),
+            ["names", "getImageFor"] => Some(NamesGetImageFor),
+            ["names", "getSignifier"] => Some(NamesGetSignifier),
             ["publish"] => Some(Publish),
             ["whoami"] => Some(WhoAmI),
-            ["get"] => Some(Get),
-            ["createHistoryStream"] => Some(CreateHistoryStream),
-            ["createFeedStream"] => Some(CreateFeedStream),
-            ["latest"] => Some(Latest),
-            ["blobs", "get"] => Some(BlobsGet),
-            ["blobs", "createWants"] => Some(BlobsCreateWants),
             _ => None,
         }
     }
@@ -90,6 +99,219 @@ impl<W: Write + Unpin> ApiCaller<W> {
 
     pub fn rpc(&mut self) -> &mut RpcWriter<W> {
         &mut self.rpc
+    }
+
+    /// Send blob create wants.
+    pub async fn blob_create_wants_req_send(&mut self) -> Result<RequestNo> {
+        let args: [&str; 0] = [];
+        let req_no = self
+            .rpc
+            .send_request(
+                ApiMethod::BlobsCreateWants.selector(),
+                RpcType::Source,
+                ArgType::Array,
+                &args,
+                &None::<()>,
+            )
+            .await?;
+        Ok(req_no)
+    }
+
+    /// Send ["blobs","get"] request.
+    pub async fn blobs_get_req_send(&mut self, args: &dto::BlobsGetIn) -> Result<RequestNo> {
+        let req_no = self
+            .rpc
+            .send_request(
+                ApiMethod::BlobsGet.selector(),
+                RpcType::Source,
+                ArgType::Array,
+                &args,
+                &None::<()>,
+            )
+            .await?;
+        Ok(req_no)
+    }
+
+    /// Send blob response.
+    pub async fn blobs_get_res_send<D: AsRef<[u8]>>(
+        &mut self,
+        req_no: RequestNo,
+        data: D,
+    ) -> Result<()> {
+        let mut offset = 0;
+        let data = data.as_ref();
+        while offset < data.len() {
+            let limit = std::cmp::min(data.len(), offset + MAX_RPC_BODY_LEN);
+            self.rpc
+                .send_response(
+                    req_no,
+                    RpcType::Source,
+                    BodyType::Binary,
+                    &data[offset..limit],
+                )
+                .await?;
+            offset += MAX_RPC_BODY_LEN;
+        }
+        self.rpc.send_stream_eof(req_no).await?;
+        Ok(())
+    }
+
+    /// Send ["createFeedStream"] request.
+    pub async fn create_feed_stream_req_send<'a>(
+        &mut self,
+        args: &dto::CreateStreamIn<u64>,
+    ) -> Result<RequestNo> {
+        let req_no = self
+            .rpc
+            .send_request(
+                ApiMethod::CreateFeedStream.selector(),
+                RpcType::Source,
+                ArgType::Array,
+                &args,
+                &None::<()>,
+            )
+            .await?;
+        Ok(req_no)
+    }
+
+    /// Send ["createHistoryStream"] request.
+    pub async fn create_history_stream_req_send(
+        &mut self,
+        args: &dto::CreateHistoryStreamIn,
+    ) -> Result<RequestNo> {
+        let req_no = self
+            .rpc
+            .send_request(
+                ApiMethod::CreateHistoryStream.selector(),
+                RpcType::Source,
+                ArgType::Array,
+                &args,
+                &None::<()>,
+            )
+            .await?;
+        Ok(req_no)
+    }
+
+    /// Send feed response.
+    pub async fn feed_res_send(&mut self, req_no: RequestNo, feed: &str) -> Result<()> {
+        self.rpc
+            .send_response(req_no, RpcType::Source, BodyType::JSON, feed.as_bytes())
+            .await?;
+        Ok(())
+    }
+
+    /// Send ["friends", "blocks"] request.
+    pub async fn friends_blocks_req_send(&mut self) -> Result<RequestNo> {
+        let args: [&str; 0] = [];
+        let req_no = self
+            .rpc
+            .send_request(
+                ApiMethod::FriendsBlocks.selector(),
+                RpcType::Source,
+                ArgType::Object,
+                &args,
+                &None::<()>,
+            )
+            .await?;
+        Ok(req_no)
+    }
+
+    /// Send ["friends", "hops"] request.
+    pub async fn friends_hops_req_send(&mut self, args: FriendsHops) -> Result<RequestNo> {
+        let req_no = self
+            .rpc
+            .send_request(
+                ApiMethod::FriendsHops.selector(),
+                RpcType::Source,
+                ArgType::Array,
+                &args,
+                &None::<()>,
+            )
+            .await?;
+        Ok(req_no)
+    }
+
+    /// Send ["friends", "isBlocking"] request.
+    pub async fn friends_is_blocking_req_send(
+        &mut self,
+        args: RelationshipQuery,
+    ) -> Result<RequestNo> {
+        let req_no = self
+            .rpc
+            .send_request(
+                ApiMethod::FriendsIsBlocking.selector(),
+                RpcType::Async,
+                ArgType::Array,
+                &args,
+                &None::<()>,
+            )
+            .await?;
+        Ok(req_no)
+    }
+
+    /// Send ["friends", "isFollowing"] request.
+    pub async fn friends_is_following_req_send(
+        &mut self,
+        args: RelationshipQuery,
+    ) -> Result<RequestNo> {
+        let req_no = self
+            .rpc
+            .send_request(
+                ApiMethod::FriendsIsFollowing.selector(),
+                RpcType::Async,
+                ArgType::Array,
+                &args,
+                &None::<()>,
+            )
+            .await?;
+        Ok(req_no)
+    }
+
+    /// Send ["get"] request.
+    pub async fn get_req_send(&mut self, msg_id: &str) -> Result<RequestNo> {
+        let req_no = self
+            .rpc
+            .send_request(
+                ApiMethod::Get.selector(),
+                RpcType::Async,
+                ArgType::Array,
+                &msg_id,
+                &None::<()>,
+            )
+            .await?;
+        Ok(req_no)
+    }
+
+    /// Send ["get"] response.
+    pub async fn get_res_send(&mut self, req_no: RequestNo, msg: &Message) -> Result<()> {
+        self.rpc
+            .send_response(
+                req_no,
+                RpcType::Async,
+                BodyType::JSON,
+                msg.to_string().as_bytes(),
+            )
+            .await?;
+        Ok(())
+    }
+
+    /// Send ["partialReplication", "getSubset"] request.
+    pub async fn getsubset_req_send(
+        &mut self,
+        query: SubsetQuery,
+        opts: Option<SubsetQueryOptions>,
+    ) -> Result<RequestNo> {
+        let req_no = self
+            .rpc
+            .send_request(
+                ApiMethod::GetSubset.selector(),
+                RpcType::Source,
+                ArgType::Tuple,
+                &query,
+                &opts,
+            )
+            .await?;
+        Ok(req_no)
     }
 
     /// Send ["invite", "create"] request.
@@ -124,66 +346,15 @@ impl<W: Write + Unpin> ApiCaller<W> {
         Ok(req_no)
     }
 
-    /// Send ["friends", "isFollowing"] request.
-    pub async fn friends_is_following_req_send(
-        &mut self,
-        args: RelationshipQuery,
-    ) -> Result<RequestNo> {
-        let req_no = self
-            .rpc
-            .send_request(
-                ApiMethod::FriendsIsFollowing.selector(),
-                RpcType::Async,
-                ArgType::Array,
-                &args,
-                &None::<()>,
-            )
-            .await?;
-        Ok(req_no)
-    }
-
-    /// Send ["friends", "isBlocking"] request.
-    pub async fn friends_is_blocking_req_send(
-        &mut self,
-        args: RelationshipQuery,
-    ) -> Result<RequestNo> {
-        let req_no = self
-            .rpc
-            .send_request(
-                ApiMethod::FriendsIsBlocking.selector(),
-                RpcType::Async,
-                ArgType::Array,
-                &args,
-                &None::<()>,
-            )
-            .await?;
-        Ok(req_no)
-    }
-
-    /// Send ["friends", "hops"] request
-    pub async fn friends_hops_req_send(&mut self, args: FriendsHops) -> Result<RequestNo> {
-        let req_no = self
-            .rpc
-            .send_request(
-                ApiMethod::FriendsHops.selector(),
-                RpcType::Source,
-                ArgType::Array,
-                &args,
-                &None::<()>,
-            )
-            .await?;
-        Ok(req_no)
-    }
-
-    /// Send ["friends", "blocks"] request
-    pub async fn friends_blocks_req_send(&mut self) -> Result<RequestNo> {
+    /// Send ["latest"] request.
+    pub async fn latest_req_send(&mut self) -> Result<RequestNo> {
         let args: [&str; 0] = [];
         let req_no = self
             .rpc
             .send_request(
-                ApiMethod::FriendsBlocks.selector(),
-                RpcType::Source,
-                ArgType::Object,
+                ApiMethod::Latest.selector(),
+                RpcType::Async,
+                ArgType::Array,
                 &args,
                 &None::<()>,
             )
@@ -191,20 +362,47 @@ impl<W: Write + Unpin> ApiCaller<W> {
         Ok(req_no)
     }
 
-    /// Send ["partialReplication", "getSubset"] request.
-    pub async fn getsubset_req_send(
-        &mut self,
-        query: SubsetQuery,
-        opts: Option<SubsetQueryOptions>,
-    ) -> Result<RequestNo> {
+    /// Send ["names", "get"] request.
+    pub async fn names_get_req_send(&mut self) -> Result<RequestNo> {
+        let args: [&str; 0] = [];
         let req_no = self
             .rpc
             .send_request(
-                ApiMethod::GetSubset.selector(),
-                RpcType::Source,
-                ArgType::Tuple,
-                &query,
-                &opts,
+                ApiMethod::NamesGet.selector(),
+                RpcType::Async,
+                ArgType::Array,
+                &args,
+                &None::<()>,
+            )
+            .await?;
+        Ok(req_no)
+    }
+
+    /// Send ["names", "getImageFor"] request.
+    pub async fn names_get_image_for_req_send(&mut self, feed_id: &str) -> Result<RequestNo> {
+        let req_no = self
+            .rpc
+            .send_request(
+                ApiMethod::NamesGetImageFor.selector(),
+                RpcType::Async,
+                ArgType::Array,
+                &feed_id,
+                &None::<()>,
+            )
+            .await?;
+        Ok(req_no)
+    }
+
+    /// Send ["names", "getSignifier"] request.
+    pub async fn names_get_signifier_req_send(&mut self, feed_id: &str) -> Result<RequestNo> {
+        let req_no = self
+            .rpc
+            .send_request(
+                ApiMethod::NamesGetSignifier.selector(),
+                RpcType::Async,
+                ArgType::Array,
+                &feed_id,
+                &None::<()>,
             )
             .await?;
         Ok(req_no)
@@ -256,148 +454,5 @@ impl<W: Write + Unpin> ApiCaller<W> {
             .rpc
             .send_response(req_no, RpcType::Async, BodyType::JSON, body.as_bytes())
             .await?)
-    }
-
-    /// Send ["get"] request.
-    pub async fn get_req_send(&mut self, msg_id: &str) -> Result<RequestNo> {
-        let req_no = self
-            .rpc
-            .send_request(
-                ApiMethod::Get.selector(),
-                RpcType::Async,
-                ArgType::Array,
-                &msg_id,
-                &None::<()>,
-            )
-            .await?;
-        Ok(req_no)
-    }
-
-    /// Send ["get"] response.
-    pub async fn get_res_send(&mut self, req_no: RequestNo, msg: &Message) -> Result<()> {
-        self.rpc
-            .send_response(
-                req_no,
-                RpcType::Async,
-                BodyType::JSON,
-                msg.to_string().as_bytes(),
-            )
-            .await?;
-        Ok(())
-    }
-
-    /// Send ["createHistoryStream"] request.
-    pub async fn create_history_stream_req_send(
-        &mut self,
-        args: &dto::CreateHistoryStreamIn,
-    ) -> Result<RequestNo> {
-        let req_no = self
-            .rpc
-            .send_request(
-                ApiMethod::CreateHistoryStream.selector(),
-                RpcType::Source,
-                ArgType::Array,
-                &args,
-                &None::<()>,
-            )
-            .await?;
-        Ok(req_no)
-    }
-
-    /// Send ["createFeedStream"] request.
-    pub async fn create_feed_stream_req_send<'a>(
-        &mut self,
-        args: &dto::CreateStreamIn<u64>,
-    ) -> Result<RequestNo> {
-        let req_no = self
-            .rpc
-            .send_request(
-                ApiMethod::CreateFeedStream.selector(),
-                RpcType::Source,
-                ArgType::Array,
-                &args,
-                &None::<()>,
-            )
-            .await?;
-        Ok(req_no)
-    }
-
-    /// Send ["latest"] request.
-    pub async fn latest_req_send(&mut self) -> Result<RequestNo> {
-        let args: [&str; 0] = [];
-        let req_no = self
-            .rpc
-            .send_request(
-                ApiMethod::Latest.selector(),
-                RpcType::Async,
-                ArgType::Array,
-                &args,
-                &None::<()>,
-            )
-            .await?;
-        Ok(req_no)
-    }
-
-    /// Send ["blobs","get"] request.
-    pub async fn blobs_get_req_send(&mut self, args: &dto::BlobsGetIn) -> Result<RequestNo> {
-        let req_no = self
-            .rpc
-            .send_request(
-                ApiMethod::BlobsGet.selector(),
-                RpcType::Source,
-                ArgType::Array,
-                &args,
-                &None::<()>,
-            )
-            .await?;
-        Ok(req_no)
-    }
-
-    /// Send feed response
-    pub async fn feed_res_send(&mut self, req_no: RequestNo, feed: &str) -> Result<()> {
-        self.rpc
-            .send_response(req_no, RpcType::Source, BodyType::JSON, feed.as_bytes())
-            .await?;
-        Ok(())
-    }
-
-    /// Send blob create wants
-    pub async fn blob_create_wants_req_send(&mut self) -> Result<RequestNo> {
-        let args: [&str; 0] = [];
-        let req_no = self
-            .rpc
-            .send_request(
-                ApiMethod::BlobsCreateWants.selector(),
-                RpcType::Source,
-                ArgType::Array,
-                &args,
-                &None::<()>,
-            )
-            .await?;
-        Ok(req_no)
-    }
-
-    /// Send blob response
-    pub async fn blobs_get_res_send<D: AsRef<[u8]>>(
-        &mut self,
-        req_no: RequestNo,
-        data: D,
-    ) -> Result<()> {
-        let mut offset = 0;
-        let data = data.as_ref();
-        while offset < data.len() {
-            let limit = std::cmp::min(data.len(), offset + MAX_RPC_BODY_LEN);
-            self.rpc
-                .send_response(
-                    req_no,
-                    RpcType::Source,
-                    BodyType::Binary,
-                    &data[offset..limit],
-                )
-                .await?;
-            offset += MAX_RPC_BODY_LEN;
-        }
-        self.rpc.send_stream_eof(req_no).await?;
-        Ok(())
     }
 }


### PR DESCRIPTION
Adds three `names` RPC calls. These methods are supported by Go-SSB and ssb-db (JS).

https://github.com/cryptoscope/ssb/blob/a781ad4ee51523df1d3858d9859c285d0eeb2fb1/sbot/manifest.go#L89

```
"names": {
    "get": "async",
    "getImageFor": "async",
    "getSignifier": "async"
},
```

According to [ssb-names](https://github.com/ssbc/ssb-names), they do the following:

get() : get all naming relationships
getImageFor(id) : get the image for an id
getSignifier(id) : get the name for an id. returns a name for this id.

------

I have also alphabetised the order of all method listings in `src/api/helper.rs`. This made the diff very noisy (sorry about that) but I think it makes the file easier to navigate.