### PR TITLE
Add tangles.thread RPC request

### DIFF
--- a/src/api/dto/mod.rs
+++ b/src/api/dto/mod.rs
@@ -4,6 +4,7 @@ mod error;
 mod history_stream;
 mod latest;
 mod stream;
+mod tangles;
 mod whoami;
 
 pub use blobs::*;
@@ -11,4 +12,5 @@ pub use error::*;
 pub use history_stream::*;
 pub use latest::*;
 pub use stream::*;
+pub use tangles::*;
 pub use whoami::*;

--- a/src/api/dto/tangles.rs
+++ b/src/api/dto/tangles.rs
@@ -1,0 +1,65 @@
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TanglesThread {
+    /// id (string, required): The key of the root message of a thread, for
+    /// which replies are to be fetched and returned.
+    pub root: String,
+
+    /// keys (boolean, default: false): whether the data event should contain
+    /// keys. If set to true and values set to false then data events will
+    /// simply be keys, rather than objects with a key property.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub keys: Option<bool>,
+
+    /// values (boolean, default: true): whether the data event should contain
+    /// values. If set to true and keys set to false then data events will
+    /// simply be values, rather than objects with a value property.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub values: Option<bool>,
+
+    /// limit (number, default: -1): limit the number of results collected by
+    /// this stream. This number represents a maximum number of results and may
+    /// not be reached if you get to the end of the data first. A value of -1
+    /// means there is no limit.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<i64>,
+
+    /// private (boolean, default: false): attempt to unbox the encrypted
+    /// messages comprising the thread. This should be set to true if the
+    /// tangle messages are private.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub private: Option<bool>,
+}
+
+impl TanglesThread {
+    pub fn new(root: String) -> Self {
+        Self {
+            root,
+            keys: None,
+            values: None,
+            limit: None,
+            private: None,
+        }
+    }
+
+    pub fn keys_values(self, keys: bool, values: bool) -> Self {
+        Self {
+            keys: Some(keys),
+            values: Some(values),
+            ..self
+        }
+    }
+
+    pub fn limit(self, limit: i64) -> Self {
+        Self {
+            limit: Some(limit),
+            ..self
+        }
+    }
+
+    pub fn private(self, private: bool) -> Self {
+        Self {
+            private: Some(private),
+            ..self
+        }
+    }
+}

--- a/src/api/helper.rs
+++ b/src/api/helper.rs
@@ -32,6 +32,7 @@ pub enum ApiMethod {
     NamesGetSignifier,
     PrivatePublish,
     Publish,
+    TanglesThread,
     WhoAmI,
 }
 
@@ -57,6 +58,7 @@ impl ApiMethod {
             NamesGetSignifier => &["names", "getSignifier"],
             PrivatePublish => &["private", "publish"],
             Publish => &["publish"],
+            TanglesThread => &["tangles", "thread"],
             WhoAmI => &["whoami"],
         }
     }
@@ -81,6 +83,7 @@ impl ApiMethod {
             ["names", "getSignifier"] => Some(NamesGetSignifier),
             ["private", "publish"] => Some(PrivatePublish),
             ["publish"] => Some(Publish),
+            ["tangles", "thread"] => Some(TanglesThread),
             ["whoami"] => Some(WhoAmI),
             _ => None,
         }
@@ -451,6 +454,24 @@ impl<W: Write + Unpin> ApiCaller<W> {
             .rpc
             .send_response(req_no, RpcType::Async, BodyType::JSON, msg_ref.as_bytes())
             .await?)
+    }
+
+    /// Send ["tangles", "thread"] request.
+    pub async fn tangles_thread_req_send(
+        &mut self,
+        args: &dto::TanglesThread,
+    ) -> Result<RequestNo> {
+        let req_no = self
+            .rpc
+            .send_request(
+                ApiMethod::TanglesThread.selector(),
+                RpcType::Source,
+                ArgType::Array,
+                &args,
+                &None::<()>,
+            )
+            .await?;
+        Ok(req_no)
     }
 
     /// Send ["whoami"] request.


### PR DESCRIPTION
`tangles.thread` takes the key of the root message of a thread and returns a stream of messages comprising the thread.

The required argument is `root` (message key).

The following options are exposed:

- limit
- keys
- values
- private

The `reverse` option has been excluded for now because it does not seem to work in the `go-ssb` implementation. This can easily be added at a later stage (the same goes for the `seq` option).