### PR TITLE
Remove unused lifetimes and implement Eq

### DIFF
--- a/src/crypto/sodium.rs
+++ b/src/crypto/sodium.rs
@@ -19,19 +19,19 @@ pub trait ToSsbId {
     fn to_ssb_id(&self) -> String;
 }
 
-impl<'a> ToSsbId for ed25519::PublicKey {
+impl ToSsbId for ed25519::PublicKey {
     fn to_ssb_id(&self) -> String {
         format!("{}{}", base64::encode(self), CURVE_ED25519_SUFFIX)
     }
 }
 
-impl<'a> ToSsbId for ed25519::SecretKey {
+impl ToSsbId for ed25519::SecretKey {
     fn to_ssb_id(&self) -> String {
         format!("{}{}", base64::encode(self), CURVE_ED25519_SUFFIX)
     }
 }
 
-impl<'a> ToSsbId for sha256::Digest {
+impl ToSsbId for sha256::Digest {
     fn to_ssb_id(&self) -> String {
         format!("{}{}", base64::encode(self), SHA256_SUFFIX)
     }

--- a/src/keystore/identity.rs
+++ b/src/keystore/identity.rs
@@ -12,7 +12,7 @@ pub struct JsonSSBSecret {
     pub public: String,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct OwnedIdentity {
     pub id: String,
     pub pk: ed25519::PublicKey,

--- a/src/rpc/stream.rs
+++ b/src/rpc/stream.rs
@@ -62,7 +62,7 @@ pub enum RpcType {
     Duplex,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct Header {
     pub req_no: RequestNo,
     pub is_stream: bool,

--- a/src/rpc/stream.rs
+++ b/src/rpc/stream.rs
@@ -21,7 +21,7 @@ pub enum ArgType {
     Object,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum BodyType {
     Binary,
     UTF8,
@@ -52,7 +52,7 @@ pub struct BodyRefWithOpts<'a, T: serde::Serialize, U: serde::Serialize> {
     pub args: (&'a T, &'a U),
 }
 
-#[derive(Clone, Copy, Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Clone, Copy, Serialize, Deserialize, Debug, Eq, PartialEq)]
 pub enum RpcType {
     #[serde(rename = "async")]
     Async,


### PR DESCRIPTION
Just a bit of housekeeping to satisfy `clippy`.

https://rust-lang.github.io/rust-clippy/master/index.html#extra_unused_lifetimes
https://rust-lang.github.io/rust-clippy/master/index.html#derive_partial_eq_without_eq