### PR TITLE
Change invite.create to send args as array (not object)

### DIFF
--- a/src/api/helper.rs
+++ b/src/api/helper.rs
@@ -328,9 +328,8 @@ impl<W: Write + Unpin> ApiCaller<W> {
             .send_request(
                 ApiMethod::InviteCreate.selector(),
                 RpcType::Async,
-                ArgType::Object,
+                ArgType::Array,
                 &args,
-                // specify None value for `opts`
                 &None::<()>,
             )
             .await?;


### PR DESCRIPTION
The reason for this change is documented in https://github.com/ssbc/go-ssb/issues/235