### PR TITLE
Make error type from discovery module public

### DIFF
--- a/src/discovery/mod.rs
+++ b/src/discovery/mod.rs
@@ -3,6 +3,8 @@ mod lan;
 mod network;
 mod pubs;
 
+pub use error::{Error, Result};
+
 pub use lan::LanBroadcast;
 pub use network::ssb_net_id;
 pub use pubs::Invite;


### PR DESCRIPTION
This follows the same pattern as other kuska modules which define their own `Error` type; allows those types to be referenced by downstream libraries and applications.