### PR TITLE
Add + character to broadcast regex pattern

### DIFF
--- a/src/discovery/lan.rs
+++ b/src/discovery/lan.rs
@@ -15,7 +15,7 @@ use crate::crypto::{ed25519, ToSodiumObject};
 use super::error::{Error, Result};
 
 pub static BROADCAST_REGEX: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"net:([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+):([0-9]+)~shs:([0-9a-zA-Z=/]+)").unwrap()
+    Regex::new(r"net:([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+):([0-9]+)~shs:([0-9a-zA-Z+=/]+)").unwrap()
 });
 
 pub struct LanBroadcast {


### PR DESCRIPTION
LAN broadcast message (multiserver address) parsing fails to match a public key containing a `+` character. For example, `@HEqy940T6uB+T+d9Jaa58aNfRzLx9eRWqkZljBmnkmk=.ed25519`.

This PR adds the `+` character to the pattern for matching.