### PR TITLE
Use u16 for port when parsing LAN broadcast address

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kuska-ssb"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Dhole <dhole@riseup.net>", "Adria Massanet <adria@codecontext.io>", "Andrew Reid <glyph@mycelial.technology>"]
 edition = "2021"
 description = "Secure Scuttlebutt library"

--- a/src/discovery/lan.rs
+++ b/src/discovery/lan.rs
@@ -68,14 +68,14 @@ impl LanBroadcast {
         }
     }
 
-    pub fn parse(msg: &str) -> Option<(String, u32, ed25519::PublicKey)> {
+    pub fn parse(msg: &str) -> Option<(String, u16, ed25519::PublicKey)> {
         let parse_shs = |addr: &str| -> Result<_> {
             let captures = BROADCAST_REGEX
                 .captures(addr)
                 .ok_or(Error::InvalidBroadcastMessage)?;
 
             let ip = captures[1].to_string();
-            let port = captures[2].parse::<u32>()?;
+            let port = captures[2].parse::<u16>()?;
             let server_pk = captures[3].to_ed25519_pk_no_suffix()?;
 
             Ok((ip, port, server_pk))


### PR DESCRIPTION
A tiny PR to parse the port value from a UDP broadcast message as `u16` (the standard) and not `u32`. 

Bumps version to `0.4.2`.