### PR TITLE
Use git path for kuska-handshake dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "AGPL-3.0"
 name = "kuska_ssb"
 
 [dependencies]
-kuska-handshake = { version = "0.2", features=["async_std"] }
+kuska-handshake = { git = "https://github.com/Kuska-ssb/handshake.git", features = ["async_std"] }
 kuska-sodiumoxide = "0.2.5-0"
 base64 = "0.11.0"
 hex = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kuska-ssb"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Dhole <dhole@riseup.net>", "Adria Massanet <adria@codecontext.io>", "Andrew Reid <glyph@mycelial.technology>"]
 edition = "2021"
 description = "Secure Scuttlebutt library"


### PR DESCRIPTION
The repo has the latest changes (ie. `Clone` implementation on `HandshakeComplete`).

Bumps the version to `0.4.3`.